### PR TITLE
Stopgap solution to using this with browserify

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -5,7 +5,6 @@
 /node_modules
 /Makefile
 /test
-/build
 *.log
 *.swp
 *~


### PR DESCRIPTION
Currently when you install this package using `npm`, the `/build` folder is npm-ignored (which includes the built css files). This patch will un-ignore that so that I can manually locate both the `.js` and `.css` files out of the box.
